### PR TITLE
Add dashes to uncertain lines

### DIFF
--- a/styles.json
+++ b/styles.json
@@ -16,6 +16,14 @@
       "maxzoom": 22,
       "source": "coastlines",
       "source-layer": "shorelines_annual",
+      "filter": [
+        "all",
+        [
+          "==",
+          "certainty",
+          "good"
+        ]
+      ],
       "paint": {
         "line-color": [
           "interpolate",
@@ -39,25 +47,53 @@
           2023,
           "#fcffa4"
         ],
-        "line-width": [
-          "match",
+        "line-width": 2.5,
+        "line-opacity": 1
+      }
+    },
+    {
+      "id": "Annual shorelines (uncertain)",
+      "type": "line",
+      "minzoom": 13,
+      "maxzoom": 22,
+      "source": "coastlines",
+      "source-layer": "shorelines_annual",
+      "filter": [
+        "all",
+        [
+          "!=",
+          "certainty",
+          "good"
+        ]
+      ],
+      "paint": {
+        "line-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
           [
             "get",
-            "certainty"
+            "year"
           ],
-          "good",
-          2.5,
-          0.85
+          1999,
+          "#000004",
+          2003,
+          "#2f0a5b",
+          2007,
+          "#801f6c",
+          2012,
+          "#d34743",
+          2017,
+          "#fb9d07",
+          2023,
+          "#fcffa4"
         ],
-        "line-opacity": [
-          "match",
-          [
-            "get",
-            "certainty"
-          ],
-          "good",
-          1,
-          0.65
+        "line-width": 2.0,
+        "line-opacity": 0.8,
+        "line-dasharray": [
+          4,
+          4
         ]
       }
     },


### PR DESCRIPTION
Added dashes. This needs duplicated layers, unfortunately, possibly because the match isn't implemented in MapLibre... just a guess though.

Anyhow, looks like this:

<img width="1125" alt="image" src="https://github.com/user-attachments/assets/d21ee3e3-33a8-490f-92cd-779d02cd7573">
